### PR TITLE
Remove markup options

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -10,9 +10,5 @@ insert_final_newline = true
 max_line_length = 120
 trim_trailing_whitespace = true
 
-[*.md]
-max_line_length = 0
-trim_trailing_whitespace = false
-
 [COMMIT_EDITMSG]
 max_line_length = 0


### PR DESCRIPTION
`max_line_length = 0` is not valid I guess, `off` is the default value

If we allow newlines by adding `trim_trailing_whitespace`, we'll end up with a mixed usage of trailing spaces and hard enters