### PR TITLE
Switch off `max_line_length`

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -7,7 +7,7 @@ end_of_line = lf
 indent_size = 2
 indent_style = space
 insert_final_newline = true
-max_line_length = 120
+max_line_length = off
 trim_trailing_whitespace = true
 
 [*.md]

--- a/.editorconfig
+++ b/.editorconfig
@@ -13,6 +13,3 @@ trim_trailing_whitespace = true
 [*.md]
 max_line_length = 0
 trim_trailing_whitespace = false
-
-[COMMIT_EDITMSG]
-max_line_length = 0


### PR DESCRIPTION
This can be annoying in html or svg files and probably some other files
